### PR TITLE
ext clock - process midi event

### DIFF
--- a/less_concepts.lua
+++ b/less_concepts.lua
@@ -101,7 +101,7 @@ selected_set = 0
 local beatclock = require 'beatclock'
 local clk = beatclock.new()
 clk_midi = midi.connect()
-clk_midi.event = clk.process_midi
+clk_midi.event = function(data) clk:process_midi(data) end
 
 clk.on_select_external = function() clk:reset() end --from nattog
 


### PR DESCRIPTION
ext clocking wasn't working on my local setup - checked the code and clk midi events were not being processed correctly. working now as expected